### PR TITLE
feat: attempt to workaround issues with subscription aliases

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -61,7 +61,7 @@ pkgs.mkShell {
   (
     # install the following tools only when not running in CI, because they are already preinstalled/expensive
     if (builtins.getEnv "CI" == "true")
-    then 
+    then
       [ ]
     else
       [

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> { } }:
+{ pkgs ? import <nixpkgs> { }, system ? builtins.currentSystem }:
 
 let
   # fake opentofu as terraform so that tools like terraform-docs pre-commit hook (which doesn't have tofu support)
@@ -6,7 +6,7 @@ let
   tofu_terraform =
     pkgs.stdenv.mkDerivation {
       name = "tofu-terraform";
-      phases = ["installPhase"];
+      phases = [ "installPhase" ];
       installPhase = ''
         mkdir -p $out/bin
         echo '#!/usr/bin/env sh' > $out/bin/terraform
@@ -23,11 +23,11 @@ let
     owner = "katexochen";
     repo = "nixpkgs";
     rev = "aacf05daec3141ce2bb34fd7c021a86401ac8c51";
-    sha256 = "11gdi69l7rdv0im4b1ka4b1gl9jiy6k4fzpk8hd44zss6w5ykhs4";     # update via nix-prefetch-url --unpack https://github.com/...
+    sha256 = "11gdi69l7rdv0im4b1ka4b1gl9jiy6k4fzpk8hd44zss6w5ykhs4"; # update via nix-prefetch-url --unpack https://github.com/...
   };
 
   # Import the fetched Nix expression
-  pkgsWithAzFixes = pkgs.callPackage pkgsWithAzFixesSrc {};
+  pkgsWithAzFixes = pkgs.callPackage pkgsWithAzFixesSrc { };
 
 in
 
@@ -47,8 +47,7 @@ pkgs.mkShell {
     # fake tofu as terraform
     tofu_terraform
 
-    # cloud provider clis
-    (pkgsWithAzFixes.azure-cli.withExtensions [ pkgsWithAzFixes.azure-cli.extensions.account ])
+
 
     # we currently don't have these managed by this collie repo, but will need it soon
     # pkgs.awscli2
@@ -58,5 +57,15 @@ pkgs.mkShell {
     pkgs.nodejs
 
     pkgs.pre-commit
-  ];
+  ] ++
+  (
+    # install the following tools only when not running in CI, because they are already preinstalled/expensive
+    if (builtins.getEnv "CI" == "true")
+    then 
+      [ ]
+    else
+      [
+        (pkgsWithAzFixes.azure-cli.withExtensions [ pkgsWithAzFixes.azure-cli.extensions.account ])
+      ]
+  );
 }

--- a/default.nix
+++ b/default.nix
@@ -15,6 +15,20 @@ let
       '';
     };
 
+  # Fetch the Nix expression from GitHub
+  # This will no longer be needed once https://github.com/NixOS/nixpkgs/pull/276695 is merged upstream.
+  # What's ugly about this is that we effectively clone the whole of nixpkgs and have to build our own azure cli...
+  # This will probably take forever on a GitHub actions runner
+  pkgsWithAzFixesSrc = pkgs.fetchFromGitHub {
+    owner = "katexochen";
+    repo = "nixpkgs";
+    rev = "aacf05daec3141ce2bb34fd7c021a86401ac8c51";
+    sha256 = "11gdi69l7rdv0im4b1ka4b1gl9jiy6k4fzpk8hd44zss6w5ykhs4";     # update via nix-prefetch-url --unpack https://github.com/...
+  };
+
+  # Import the fetched Nix expression
+  pkgsWithAzFixes = pkgs.callPackage pkgsWithAzFixesSrc {};
+
 in
 
 pkgs.mkShell {
@@ -34,7 +48,7 @@ pkgs.mkShell {
     tofu_terraform
 
     # cloud provider clis
-    pkgs.azure-cli
+    (pkgsWithAzFixes.azure-cli.withExtensions [ pkgsWithAzFixes.azure-cli.extensions.account ])
 
     # we currently don't have these managed by this collie repo, but will need it soon
     # pkgs.awscli2

--- a/foundations/likvid-dev/platforms/azure/organization-hierarchy/.terraform.lock.hcl
+++ b/foundations/likvid-dev/platforms/azure/organization-hierarchy/.terraform.lock.hcl
@@ -2,21 +2,36 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.opentofu.org/hashicorp/azurerm" {
-  version     = "3.71.0"
-  constraints = "~> 3.71.0"
+  version     = "3.97.1"
+  constraints = "~> 3.97.0"
   hashes = [
-    "h1:RgYFB7Zq3YWHLCFt1VzSESVPeSu+aNM6FttlTlWFb+o=",
-    "h1:gL2jQo/xHIFOs3yLqZ04+aksSk4PxDasgJtyg8HgmOg=",
-    "h1:pMFZp3gNXrRLkvBpu8nxnmE0lJURl/jpHQVWSZCjacQ=",
-    "zh:6a3fb5ec42fb3ba0f8bf2d33135b009778d44f1369b7cf0e32d82f09090d0a5f",
-    "zh:7bdf491c3e5d8d834970e3dd4cc0a8095e9377d01ad1de4a8673d4672ceff14e",
-    "zh:8f0a73ff1866a1958141e8d65d499fff7cf82deda770872909a5913383d721dd",
-    "zh:92a36f8fcaa23a9064596fcaa4380ccfc2da2361b11fdf78fced12786f0cdceb",
-    "zh:96a719d785a1b922dff22b0aa8eb840145c965e9bbc096d174135f0f0091b674",
-    "zh:b69ed332180545c30dd05771336d16ade004355ba4b272bc692c7713cefb5295",
-    "zh:d482ef91aff6ecbfcca10fb72d1ee4559c683d3c583539d79bdfebe5766bf7c7",
-    "zh:e9123b267a41918d6f0d2b8156ce828b03ba88056b1e21729de090c73a0f9560",
-    "zh:f073862ac21b7262c24193f2e1ea23973f12ac53ac61cb27b569c2b834935751",
-    "zh:f86c8cc85dcd2f35f19cd7da45a8eeaa5ffa8213f5eccfa2bc28836cb4f7e742",
+    "h1:3dkdNcbivRDtA7eAj9If1xwpP2VFrmDJUL4vdaob4Z0=",
+    "zh:48235181f6dd20b258625b8bbab58271a23a1be55f1568e1e674394e4cca0956",
+    "zh:4e85e74ec0a484fa4dbc4c9416c022c3c48c7961e8c36d67e956ad40bb017eea",
+    "zh:61b1a86518c41beea596fd49ec1d40def3a05f145550848aac8e12e2c51c1dea",
+    "zh:6eee44eb01803e25b3845c502f0f92da7cbf59f31ca203e610046a80eb19cbff",
+    "zh:764f3d8bfc7aee697568d85a8414fa8b900c35dc1eb95cfa6d2b251e422ca425",
+    "zh:8726586f45abe9789739c4bd2ebbed37d85ad91e27ee70324efe634d4e3a60cf",
+    "zh:ba64ba0c0f14baadd2ea9089aba3879c1cd61651458cfd4259dbedf1925b02a0",
+    "zh:eb99392a50960caaabb2bb0c5b9e90469ce2a4273ddf9861745a8b4b16991e1e",
+    "zh:edddd5f9bf87cf01aec09432f43d250575d01bc2a95328e9c250bebd14f14970",
+    "zh:eff5a3dae993681b72f007a95f4213cc776438babded81183d0ed799c9095646",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version = "3.2.2"
+  hashes = [
+    "h1:sU0t6ANQ4IfEwZbbBmcNeOCg2CDCViVb7L7QVfIHrCs=",
+    "zh:00e5877d19fb1c1d8c4b3536334a46a5c86f57146fd115c7b7b4b5d2bf2de86d",
+    "zh:1755c2999e73e4d73f9de670c145c9a0dc5a373802799dff06a0e9c161354163",
+    "zh:2b29d706353bc9c4edda6a2946af3322abe94372ffb421d81fa176f1e57e33be",
+    "zh:34f65259c6d2bd51582b6da536e782b181b23725782b181193b965f519fbbacd",
+    "zh:370f6eb744475926a1fa7464d82d46ad83c2e1148b4b21681b4cec4d75b97969",
+    "zh:5950bdb23b4fcc6431562d7eba3dea37844aa4220c4da2eb898ae3e4d1b64ec4",
+    "zh:8f3d5c8d4b9d497fec36953a227f80c76d37fc8431b683a23fb1c42b9cccbf8a",
+    "zh:8f6eb5e65c047bf490ad3891efecefc488503b65898d4ee106f474697ba257d7",
+    "zh:a7040eed688316fe00379574c72bb8c47dbe2638b038bb705647cbf224de8f72",
+    "zh:e561f28df04d9e51b75f33004b7767a53c45ad96e3375d86181ba1363bffbc77",
   ]
 }

--- a/foundations/likvid-dev/platforms/azure/organization-hierarchy/.terraform.lock.hcl
+++ b/foundations/likvid-dev/platforms/azure/organization-hierarchy/.terraform.lock.hcl
@@ -18,20 +18,3 @@ provider "registry.opentofu.org/hashicorp/azurerm" {
     "zh:eff5a3dae993681b72f007a95f4213cc776438babded81183d0ed799c9095646",
   ]
 }
-
-provider "registry.opentofu.org/hashicorp/null" {
-  version = "3.2.2"
-  hashes = [
-    "h1:sU0t6ANQ4IfEwZbbBmcNeOCg2CDCViVb7L7QVfIHrCs=",
-    "zh:00e5877d19fb1c1d8c4b3536334a46a5c86f57146fd115c7b7b4b5d2bf2de86d",
-    "zh:1755c2999e73e4d73f9de670c145c9a0dc5a373802799dff06a0e9c161354163",
-    "zh:2b29d706353bc9c4edda6a2946af3322abe94372ffb421d81fa176f1e57e33be",
-    "zh:34f65259c6d2bd51582b6da536e782b181b23725782b181193b965f519fbbacd",
-    "zh:370f6eb744475926a1fa7464d82d46ad83c2e1148b4b21681b4cec4d75b97969",
-    "zh:5950bdb23b4fcc6431562d7eba3dea37844aa4220c4da2eb898ae3e4d1b64ec4",
-    "zh:8f3d5c8d4b9d497fec36953a227f80c76d37fc8431b683a23fb1c42b9cccbf8a",
-    "zh:8f6eb5e65c047bf490ad3891efecefc488503b65898d4ee106f474697ba257d7",
-    "zh:a7040eed688316fe00379574c72bb8c47dbe2638b038bb705647cbf224de8f72",
-    "zh:e561f28df04d9e51b75f33004b7767a53c45ad96e3375d86181ba1363bffbc77",
-  ]
-}

--- a/foundations/likvid-prod/platforms/azure/organization-hierarchy/.terraform.lock.hcl
+++ b/foundations/likvid-prod/platforms/azure/organization-hierarchy/.terraform.lock.hcl
@@ -20,3 +20,20 @@ provider "registry.opentofu.org/hashicorp/azurerm" {
     "zh:eff5a3dae993681b72f007a95f4213cc776438babded81183d0ed799c9095646",
   ]
 }
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version = "3.2.2"
+  hashes = [
+    "h1:sU0t6ANQ4IfEwZbbBmcNeOCg2CDCViVb7L7QVfIHrCs=",
+    "zh:00e5877d19fb1c1d8c4b3536334a46a5c86f57146fd115c7b7b4b5d2bf2de86d",
+    "zh:1755c2999e73e4d73f9de670c145c9a0dc5a373802799dff06a0e9c161354163",
+    "zh:2b29d706353bc9c4edda6a2946af3322abe94372ffb421d81fa176f1e57e33be",
+    "zh:34f65259c6d2bd51582b6da536e782b181b23725782b181193b965f519fbbacd",
+    "zh:370f6eb744475926a1fa7464d82d46ad83c2e1148b4b21681b4cec4d75b97969",
+    "zh:5950bdb23b4fcc6431562d7eba3dea37844aa4220c4da2eb898ae3e4d1b64ec4",
+    "zh:8f3d5c8d4b9d497fec36953a227f80c76d37fc8431b683a23fb1c42b9cccbf8a",
+    "zh:8f6eb5e65c047bf490ad3891efecefc488503b65898d4ee106f474697ba257d7",
+    "zh:a7040eed688316fe00379574c72bb8c47dbe2638b038bb705647cbf224de8f72",
+    "zh:e561f28df04d9e51b75f33004b7767a53c45ad96e3375d86181ba1363bffbc77",
+  ]
+}

--- a/foundations/likvid-prod/platforms/azure/organization-hierarchy/.terraform.lock.hcl
+++ b/foundations/likvid-prod/platforms/azure/organization-hierarchy/.terraform.lock.hcl
@@ -20,20 +20,3 @@ provider "registry.opentofu.org/hashicorp/azurerm" {
     "zh:eff5a3dae993681b72f007a95f4213cc776438babded81183d0ed799c9095646",
   ]
 }
-
-provider "registry.opentofu.org/hashicorp/null" {
-  version = "3.2.2"
-  hashes = [
-    "h1:sU0t6ANQ4IfEwZbbBmcNeOCg2CDCViVb7L7QVfIHrCs=",
-    "zh:00e5877d19fb1c1d8c4b3536334a46a5c86f57146fd115c7b7b4b5d2bf2de86d",
-    "zh:1755c2999e73e4d73f9de670c145c9a0dc5a373802799dff06a0e9c161354163",
-    "zh:2b29d706353bc9c4edda6a2946af3322abe94372ffb421d81fa176f1e57e33be",
-    "zh:34f65259c6d2bd51582b6da536e782b181b23725782b181193b965f519fbbacd",
-    "zh:370f6eb744475926a1fa7464d82d46ad83c2e1148b4b21681b4cec4d75b97969",
-    "zh:5950bdb23b4fcc6431562d7eba3dea37844aa4220c4da2eb898ae3e4d1b64ec4",
-    "zh:8f3d5c8d4b9d497fec36953a227f80c76d37fc8431b683a23fb1c42b9cccbf8a",
-    "zh:8f6eb5e65c047bf490ad3891efecefc488503b65898d4ee106f474697ba257d7",
-    "zh:a7040eed688316fe00379574c72bb8c47dbe2638b038bb705647cbf224de8f72",
-    "zh:e561f28df04d9e51b75f33004b7767a53c45ad96e3375d86181ba1363bffbc77",
-  ]
-}

--- a/foundations/likvid-prod/platforms/azure/organization-hierarchy/terragrunt.hcl
+++ b/foundations/likvid-prod/platforms/azure/organization-hierarchy/terragrunt.hcl
@@ -29,11 +29,9 @@ inputs = {
   locations = ["germanywestcentral", "westeurope"]
 
   connectivity          = "likvid-connectivity"
-  corp                  = "likvid-corp"
   identity              = "likvid-identity"
   landingzones          = "likvid-landingzones"
   management            = "likvid-management"
-  online                = "likvid-online"
   parentManagementGroup = "likvid-foundation"
   platform              = "likvid-platform"
 

--- a/kit/azure/bootstrap/README.md
+++ b/kit/azure/bootstrap/README.md
@@ -97,7 +97,6 @@ collie foundation deploy --bootstrap -- destroy
 | [azurerm_role_assignment.docs_tfstate](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.tfstates_engineers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_definition.cloudfoundation_deploy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
-| [azurerm_role_definition.cloudfoundation_plan](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
 | [azurerm_user_assigned_identity.docs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
 | [azuread_users.platform_engineers_members](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/users) | data source |

--- a/kit/azure/bootstrap/resources.docs-spn.tf
+++ b/kit/azure/bootstrap/resources.docs-spn.tf
@@ -34,36 +34,10 @@ resource "azurerm_role_assignment" "docs_tfstate" {
   scope        = module.terraform_state[0].container_id
 }
 
-
-resource "azurerm_role_definition" "cloudfoundation_plan" {
-  count = var.terraform_state_storage != null && var.documentation_uami != null ? 1 : 0
-
-  name        = azurerm_user_assigned_identity.docs[0].name
-  scope       = data.azurerm_management_group.parent.id
-  description = "Permissions required to plan deployments of the cloudfoundation"
-
-  permissions {
-    actions = [
-      # equivalent to the global reader role, this is an easy way to enable the SPN to run terraform plans and detect drift
-      "*/read",
-
-      # required by the azurerm_subscription resource, even for terraform plans
-      # https://github.com/hashicorp/terraform-provider-azurerm/issues/23014 still exists as an issue though
-      "Microsoft.Subscription/aliases/read",
-      "Microsoft.Subscription/aliases/write",
-      "Microsoft.Subscription/aliases/delete"
-    ]
-  }
-
-  assignable_scopes = [
-    data.azurerm_management_group.parent.id
-  ]
-}
-
 resource "azurerm_role_assignment" "docs_reader" {
   count = var.terraform_state_storage != null && var.documentation_uami != null ? 1 : 0
 
-  scope              = data.azurerm_management_group.parent.id
-  role_definition_id = azurerm_role_definition.cloudfoundation_plan[0].role_definition_resource_id
-  principal_id       = azurerm_user_assigned_identity.docs[0].principal_id
+  scope                = data.azurerm_management_group.parent.id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_user_assigned_identity.docs[0].principal_id
 }

--- a/kit/azure/buildingblocks/subscription/buildingblock/main.tf
+++ b/kit/azure/buildingblocks/subscription/buildingblock/main.tf
@@ -1,11 +1,14 @@
 data "azurerm_subscription" "current" {
 }
 
-// set name, tags
-resource "azurerm_subscription" "this" {
-  subscription_id   = data.azurerm_subscription.current.subscription_id
-  subscription_name = var.subscription_name
+# workaround for https://github.com/hashicorp/terraform-provider-azurerm/issues/23014
+resource "terraform_data" "subscription_name" {
+  provisioner "local-exec" {
+    when    = create
+    command = "az account subscription rename --id ${data.azurerm_subscription.current.subscription_id} --name ${var.subscription_name}"
+  }
 }
+
 
 // control placement in the LZ hierarchy
 resource "azurerm_management_group_subscription_association" "lz" {

--- a/kit/azure/logging/README.md
+++ b/kit/azure/logging/README.md
@@ -62,12 +62,14 @@ AzureActivity
 | [azurerm_log_analytics_workspace.law](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_management_group_subscription_association.logging](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group_subscription_association) | resource |
 | [azurerm_resource_group.law_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_role_assignment.cloudfoundation_tfdeploy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.logging](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.security_admins](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.security_admins_law](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.security_auditors](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.security_auditors_law](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_subscription.logging](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subscription) | resource |
+| [azurerm_role_definition.cloudfoundation_tfdeploy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
+| [terraform_data.subscription_name](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs

--- a/kit/azure/logging/main.tf
+++ b/kit/azure/logging/main.tf
@@ -1,11 +1,13 @@
 # configure our logging subscription
 data "azurerm_subscription" "current" {
 }
-
-#  add a name to the existing subscription
-resource "azurerm_subscription" "logging" {
-  subscription_id   = data.azurerm_subscription.current.subscription_id
-  subscription_name = var.logging_subscription_name
+  
+# workaround for https://github.com/hashicorp/terraform-provider-azurerm/issues/23014
+resource "terraform_data" "subscription_name" {
+  provisioner "local-exec" {
+    when    = create
+    command = "az account subscription rename --id ${data.azurerm_subscription.current.subscription_id} --name ${var.logging_subscription_name}"
+  }
 }
 
 resource "azurerm_management_group_subscription_association" "logging" {

--- a/kit/azure/logging/outputs.tf
+++ b/kit/azure/logging/outputs.tf
@@ -7,7 +7,7 @@ output "security_auditors_azuread_group_id" {
 }
 
 output "logging_subscription" {
-  value = azurerm_subscription.logging.id
+  value = data.azurerm_subscription.current.id
 }
 
 output "law_workspace_id" {

--- a/kit/azure/networking/README.md
+++ b/kit/azure/networking/README.md
@@ -70,10 +70,10 @@ No modules.
 | [azurerm_subnet.mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_subnet_network_security_group_association.mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association) | resource |
 | [azurerm_subnet_route_table_association.mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_route_table_association) | resource |
-| [azurerm_subscription.networking](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subscription) | resource |
 | [azurerm_virtual_network.hub_network](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 | [random_string.dns](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [random_string.resource_code](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [terraform_data.subscription_name](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [azurerm_monitor_diagnostic_categories.fw](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_diagnostic_categories) | data source |
 | [azurerm_monitor_diagnostic_categories.fw_pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_diagnostic_categories) | data source |
 | [azurerm_monitor_diagnostic_categories.hub](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_diagnostic_categories) | data source |

--- a/kit/azure/networking/resources.network.tf
+++ b/kit/azure/networking/resources.network.tf
@@ -1,9 +1,12 @@
 data "azurerm_subscription" "current" {
 }
 
-resource "azurerm_subscription" "networking" {
-  subscription_id   = data.azurerm_subscription.current.subscription_id
-  subscription_name = var.hub_subscription_name
+# workaround for https://github.com/hashicorp/terraform-provider-azurerm/issues/23014
+resource "terraform_data" "subscription_name" {
+  provisioner "local-exec" {
+    when    = create
+    command = "az account subscription rename --id ${data.azurerm_subscription.current.subscription_id} --name ${var.hub_subscription_name}"
+  }
 }
 
 resource "azurerm_management_group_subscription_association" "vnet" {

--- a/kit/azure/organization-hierarchy/README.md
+++ b/kit/azure/organization-hierarchy/README.md
@@ -76,7 +76,7 @@ After deploying this module, you should probably deploy the following kit module
 | [azurerm_management_group.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group) | resource |
 | [azurerm_management_group.platform](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group) | resource |
 | [azurerm_management_group_subscription_association.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group_subscription_association) | resource |
-| [null_resource.management_subscription_name](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [terraform_data.management_subscription_name](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [azurerm_management_group.parent](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/management_group) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 

--- a/kit/azure/organization-hierarchy/README.md
+++ b/kit/azure/organization-hierarchy/README.md
@@ -76,7 +76,7 @@ After deploying this module, you should probably deploy the following kit module
 | [azurerm_management_group.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group) | resource |
 | [azurerm_management_group.platform](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group) | resource |
 | [azurerm_management_group_subscription_association.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group_subscription_association) | resource |
-| [azurerm_subscription.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subscription) | resource |
+| [null_resource.management_subscription_name](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [azurerm_management_group.parent](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/management_group) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 

--- a/kit/azure/organization-hierarchy/main.tf
+++ b/kit/azure/organization-hierarchy/main.tf
@@ -52,10 +52,13 @@ resource "azurerm_management_group" "management" {
 data "azurerm_subscription" "current" {
 }
 
-resource "azurerm_subscription" "management" {
-  # note: by specifying a subscription_id the terraform provider will "adopt" the existing subscription
-  subscription_id   = data.azurerm_subscription.current.subscription_id
-  subscription_name = var.management_subscription_name
+
+resource "null_resource" "management_subscription_name" {
+  # note: we assume we are running azure CLI with CLI authentication, which should hopefully also work in CI
+  provisioner "local-exec" {
+    when    = create
+    command = "az account subscription rename --id ${data.azurerm_subscription.current.subscription_id} --name ${var.management_subscription_name}"
+  }
 }
 
 resource "azurerm_management_group_subscription_association" "management" {

--- a/kit/azure/organization-hierarchy/main.tf
+++ b/kit/azure/organization-hierarchy/main.tf
@@ -52,8 +52,8 @@ resource "azurerm_management_group" "management" {
 data "azurerm_subscription" "current" {
 }
 
-
-resource "null_resource" "management_subscription_name" {
+# workaround for https://github.com/hashicorp/terraform-provider-azurerm/issues/23014
+resource "terraform_data" "management_subscription_name" {
   # note: we assume we are running azure CLI with CLI authentication, which should hopefully also work in CI
   provisioner "local-exec" {
     when    = create


### PR DESCRIPTION
azurerm_subscription creates subscription aliases. Subscription aliases have their completely own RBAC world, cf. https://github.com/jtracey93/AzureSubscriptionVendingFunction?tab=readme-ov-file#azure-subscription-alias---explained

The problem with that is that the docs SPN has no permission over the alias to read it, and thus running terraform plan fails in CI.

We therefore try working around it by setting subscription names via azure cli...

See https://github.com/hashicorp/terraform-provider-azurerm/issues/23014 and https://github.com/hashicorp/terraform-provider-azurerm/issues/15212#issuecomment-1237166405 for further references about this issue.