### PR TITLE
chore: moving error info because wrong place for such info

### DIFF
--- a/kit/azure/buildingblocks/connectivity/buildingblock/connectivity.tftest.hcl
+++ b/kit/azure/buildingblocks/connectivity/buildingblock/connectivity.tftest.hcl
@@ -16,3 +16,19 @@ run "verify" {
   }
 }
 
+# this is sometimes flaky: add additional sync checks
+
+# ╷
+# │ Error: waiting for Virtual Network Peering: (Name "terraform-test" / Virtual Network Name "hub-vnet" / Resource Group "likvid-hub-vnet-rg") to be created: network.VirtualNetworkPeeringsClient#CreateOrUpdate: Failure sending request: StatusCode=403 -- Original Error: Code="LinkedAuthorizationFailed" Message="The client 'dca119ef-092d-41ce-83d3-920d4eda271a' with object id 'dca119ef-092d-41ce-83d3-920d4eda271a' has permission to perform action 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings/write' on scope '/subscriptions/5066eff7-4173-4fea-8c67-268456b4a4f7/resourceGroups/likvid-hub-vnet-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet/virtualNetworkPeerings/terraform-test'; however, it does not have permission to perform action(s) 'Microsoft.Network/virtualNetworks/peer/action' on the linked scope(s) '/subscriptions/c4a1f7bc-9a89-4a8d-a03f-3df5c639bd5d/resourceGroups/connectivity/providers/Microsoft.Network/virtualNetworks/terraform-test-vnet' (respectively) or the linked scope(s) are invalid."
+# │
+# │   with azurerm_virtual_network_peering.hub_spoke_peer,
+# │   on main.tf line 64, in resource "azurerm_virtual_network_peering" "hub_spoke_peer":
+# │   64: resource "azurerm_virtual_network_peering" "hub_spoke_peer" {
+# │
+# ╵
+# integration.tftest.hcl... fail
+
+# Failure! 0 passed, 1 failed.
+# ERRO[0163] terraform invocation failed in /Users/jrudolph/dev/mc/likvid-cloudfoundation/foundations/likvid-prod/platforms/azure/buildingblocks/connectivity.test/.terragrunt-cache/oOe4Dx4PzIk_W5GjrRfnDKuz-Yk/Y5Jm2BYHj1OMAGX-ddMr-eJBvFs/kit/azure/buildingblocks/connectivity/buildingblock  prefix=[/Users/jrudolph/dev/mc/likvid-cloudfoundation/foundations/likvid-prod/platforms/azure/buildingblocks/connectivity.test]
+# ERRO[0163] 1 error occurred:
+#         * [/Users/jrudolph/dev/mc/likvid-cloudfoundation/foundations/likvid-prod/platforms/azure/buildingblocks/connectivity.test/.terragrunt-cache/oOe4Dx4PzIk_W5GjrRfnDKuz-Yk/Y5Jm2BYHj1OMAGX-ddMr-eJBvFs/kit/azure/buildingblocks/connectivity/buildingblock] exit status 1

--- a/kit/azure/buildingblocks/connectivity/buildingblock/main.tf
+++ b/kit/azure/buildingblocks/connectivity/buildingblock/main.tf
@@ -68,21 +68,3 @@ resource "azurerm_virtual_network_peering" "hub_spoke_peer" {
   virtual_network_name      = data.azurerm_virtual_network.hub_vnet.name
   remote_virtual_network_id = azurerm_virtual_network.spoke_vnet.id
 }
-
-
-# this is sometimes flaky: add additional sync checks
-
-# ╷
-# │ Error: waiting for Virtual Network Peering: (Name "terraform-test" / Virtual Network Name "hub-vnet" / Resource Group "likvid-hub-vnet-rg") to be created: network.VirtualNetworkPeeringsClient#CreateOrUpdate: Failure sending request: StatusCode=403 -- Original Error: Code="LinkedAuthorizationFailed" Message="The client 'dca119ef-092d-41ce-83d3-920d4eda271a' with object id 'dca119ef-092d-41ce-83d3-920d4eda271a' has permission to perform action 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings/write' on scope '/subscriptions/5066eff7-4173-4fea-8c67-268456b4a4f7/resourceGroups/likvid-hub-vnet-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet/virtualNetworkPeerings/terraform-test'; however, it does not have permission to perform action(s) 'Microsoft.Network/virtualNetworks/peer/action' on the linked scope(s) '/subscriptions/c4a1f7bc-9a89-4a8d-a03f-3df5c639bd5d/resourceGroups/connectivity/providers/Microsoft.Network/virtualNetworks/terraform-test-vnet' (respectively) or the linked scope(s) are invalid."
-# │
-# │   with azurerm_virtual_network_peering.hub_spoke_peer,
-# │   on main.tf line 64, in resource "azurerm_virtual_network_peering" "hub_spoke_peer":
-# │   64: resource "azurerm_virtual_network_peering" "hub_spoke_peer" {
-# │
-# ╵
-# integration.tftest.hcl... fail
-
-# Failure! 0 passed, 1 failed.
-# ERRO[0163] terraform invocation failed in /Users/jrudolph/dev/mc/likvid-cloudfoundation/foundations/likvid-prod/platforms/azure/buildingblocks/connectivity.test/.terragrunt-cache/oOe4Dx4PzIk_W5GjrRfnDKuz-Yk/Y5Jm2BYHj1OMAGX-ddMr-eJBvFs/kit/azure/buildingblocks/connectivity/buildingblock  prefix=[/Users/jrudolph/dev/mc/likvid-cloudfoundation/foundations/likvid-prod/platforms/azure/buildingblocks/connectivity.test]
-# ERRO[0163] 1 error occurred:
-#         * [/Users/jrudolph/dev/mc/likvid-cloudfoundation/foundations/likvid-prod/platforms/azure/buildingblocks/connectivity.test/.terragrunt-cache/oOe4Dx4PzIk_W5GjrRfnDKuz-Yk/Y5Jm2BYHj1OMAGX-ddMr-eJBvFs/kit/azure/buildingblocks/connectivity/buildingblock] exit status 1


### PR DESCRIPTION
I moved the error message to the tftest files because it should not part of the kit tf files. 