### PR TITLE
chore: remove azurecaf provider

### DIFF
--- a/foundations/likvid-dev/platforms/azure/bootstrap/.terraform.lock.hcl
+++ b/foundations/likvid-dev/platforms/azure/bootstrap/.terraform.lock.hcl
@@ -1,29 +1,6 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.opentofu.org/aztfmod/azurecaf" {
-  version     = "1.2.28"
-  constraints = "~> 1.2.26"
-  hashes = [
-    "h1:RVsdmzqbjnTGKahU5vpC/qPklRWdSweUKPp+0A/6c60=",
-    "h1:mYyiClMYdRE6pIWgmRlvOVL58CC2yZOo1BiHuMjJap0=",
-    "h1:nN8fopM4x2M3uGYonAoMO5oR4m7pUgDi6UHLyxutub0=",
-    "zh:1429bb7a873cdd69e324eaa96a3847ee9363d69ce360126b47b56e419863b024",
-    "zh:29fe1eedb502e887b543c425b6fc9cb2cb5d3d1e69f830b6a4781dbe79d61ef1",
-    "zh:340dd7ffebf3e3c5fd1d978166902c4544396a22853b6007f371aead8c92cbb3",
-    "zh:39edc570f3df0c55a3f5732d58bd7bea2d82a9df3e1bb3c04ab0b006b0a6e6fe",
-    "zh:3f5ffd5501fbea3acac04ef6337781dc51df9e9b076da86fcb275aec365f9042",
-    "zh:567872fb245c61d2dfb69f385636c3638db39c2a25161545b7cb9b5f8abced9f",
-    "zh:615c387b5459e7499bf5210e55ee83afcc77456ccaecc1f4d643e08582afe65b",
-    "zh:799dee6d755149ac7ee463e2f72f7b62fa1f6a7cf6d4d86dc4ae6592c03bcf8d",
-    "zh:902289eb256831406553da3b2409fbf03cd142385dd0392911207f0b5f6920b5",
-    "zh:914c0c9554f95d585b90f67e1df0080e8667cb9e7909e360de173b20b76e4625",
-    "zh:b6ab4bda123d57bbb98b6046c2aa7dea130be5988c3ac4f5be044ac5b51d2205",
-    "zh:d0f707439784b6b3c88b85a9d3261da793a618e5c55fa6af6f73175f4513b7c3",
-    "zh:d384404e1b6613e9cf75415c3e63d58a51c1b54406f6f62760608e0fcb476874",
-  ]
-}
-
 provider "registry.opentofu.org/hashicorp/azuread" {
   version = "2.46.0"
   hashes = [

--- a/foundations/likvid-prod/platforms/azure/bootstrap/.terraform.lock.hcl
+++ b/foundations/likvid-prod/platforms/azure/bootstrap/.terraform.lock.hcl
@@ -1,27 +1,6 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.opentofu.org/aztfmod/azurecaf" {
-  version     = "1.2.28"
-  constraints = "~> 1.2.26"
-  hashes = [
-    "h1:mYyiClMYdRE6pIWgmRlvOVL58CC2yZOo1BiHuMjJap0=",
-    "zh:1429bb7a873cdd69e324eaa96a3847ee9363d69ce360126b47b56e419863b024",
-    "zh:29fe1eedb502e887b543c425b6fc9cb2cb5d3d1e69f830b6a4781dbe79d61ef1",
-    "zh:340dd7ffebf3e3c5fd1d978166902c4544396a22853b6007f371aead8c92cbb3",
-    "zh:39edc570f3df0c55a3f5732d58bd7bea2d82a9df3e1bb3c04ab0b006b0a6e6fe",
-    "zh:3f5ffd5501fbea3acac04ef6337781dc51df9e9b076da86fcb275aec365f9042",
-    "zh:567872fb245c61d2dfb69f385636c3638db39c2a25161545b7cb9b5f8abced9f",
-    "zh:615c387b5459e7499bf5210e55ee83afcc77456ccaecc1f4d643e08582afe65b",
-    "zh:799dee6d755149ac7ee463e2f72f7b62fa1f6a7cf6d4d86dc4ae6592c03bcf8d",
-    "zh:902289eb256831406553da3b2409fbf03cd142385dd0392911207f0b5f6920b5",
-    "zh:914c0c9554f95d585b90f67e1df0080e8667cb9e7909e360de173b20b76e4625",
-    "zh:b6ab4bda123d57bbb98b6046c2aa7dea130be5988c3ac4f5be044ac5b51d2205",
-    "zh:d0f707439784b6b3c88b85a9d3261da793a618e5c55fa6af6f73175f4513b7c3",
-    "zh:d384404e1b6613e9cf75415c3e63d58a51c1b54406f6f62760608e0fcb476874",
-  ]
-}
-
 provider "registry.opentofu.org/hashicorp/azuread" {
   version     = "2.46.0"
   constraints = "~> 2.46.0"

--- a/kit/azure/bootstrap/terraform-state/version.tf
+++ b/kit/azure/bootstrap/terraform-state/version.tf
@@ -1,9 +1,3 @@
 terraform {
   required_version = ">= 1.0"
-  required_providers {
-    azurecaf = {
-      source  = "aztfmod/azurecaf"
-      version = "~> 1.2.26"
-    }
-  }
 }


### PR DESCRIPTION
we don't use that provider anymore, iirc it was only useful to generate resource names