### PR TITLE
feat: improve reliability of connectivity module using time_sleep

### DIFF
--- a/foundations/likvid-prod/platforms/azure/buildingblocks/connectivity.test/.terraform.lock.hcl
+++ b/foundations/likvid-prod/platforms/azure/buildingblocks/connectivity.test/.terraform.lock.hcl
@@ -20,3 +20,21 @@ provider "registry.opentofu.org/hashicorp/azurerm" {
     "zh:eff5a3dae993681b72f007a95f4213cc776438babded81183d0ed799c9095646",
   ]
 }
+
+provider "registry.opentofu.org/hashicorp/time" {
+  version     = "0.11.1"
+  constraints = "0.11.1"
+  hashes = [
+    "h1:+S9YvR/HeCxFGMS3ITjOFqlWrR6DdarWWowT9Cz18/M=",
+    "zh:048c56f9f810f67a7460363a26bf3ef939d64f0d7b7342b9e7f24cc85ee1491b",
+    "zh:49f949cc5cb50fbb65f7b4578b79fbe02b6bafe9e3f5f1c2936114dd445b84b3",
+    "zh:553174a4fa88f6e186800d7ee155a6b5b4c6c81793643f1a20eab26becc7f823",
+    "zh:5cae304e21f77091d4b50389c655afd5e4e2e8d4cd9c06de139a31b8e7d343a9",
+    "zh:7aae20832bd9885f034831aa44db3a6ffcec034a2d5a2815d92c42c40c14ca1d",
+    "zh:93d715610dce777474b5eff1d7dbe797e72ca0b679cd8636efb3aa45d1cb589e",
+    "zh:bd29e04645775851eb10e7f3b39104ae57ca3632dec4ae07328d33d4182e7fb5",
+    "zh:d6ad6a4d52a6989b8452466f2ec3dbcdb00cc44a96bd1ca618d91a5d74895f49",
+    "zh:e68cfad3ec526631410fa9406938d624fd56b9ab065c76525cb3f731d106fbfe",
+    "zh:ffee8aa6b7ce56f4b8fdc0c492404be0041137a278388eb1d1180b637fb5b3de",
+  ]
+}

--- a/kit/azure/buildingblocks/connectivity/buildingblock/main.tf
+++ b/kit/azure/buildingblocks/connectivity/buildingblock/main.tf
@@ -1,9 +1,14 @@
-#
-# 1. deploy the resource group
-#
+locals {
+  azure_delay = "${var.azure_delay_seconds}s"
+}
+
 data "azurerm_client_config" "spoke" {
   provider = azurerm.spoke
 }
+
+#
+# 1. deploy the resource group
+#
 
 resource "azurerm_resource_group" "spoke_rg" {
   provider = azurerm.spoke
@@ -23,12 +28,23 @@ resource "azurerm_role_assignment" "spoke_rg" {
   scope                = azurerm_resource_group.spoke_rg.id
 }
 
+# Wait for the role assignment to become effective, azure is eventually consistent and thus sometimes flaky
+# even though the azurerm_role_assignment provider tries to cover for that, it's not always effective.
+# Example:
+# > Error: checking for presence of existing Virtual Network (Subscription: "b53caa89-ba38-4f04-a0b2-f989c98d4add"
+# > Resource Group Name: "connectivity"
+# > Virtual Network Name: "vnet-demo-app-vnet"): network.VirtualNetworksClient#Get: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="AuthorizationFailed" Message="The client 'dca119ef-092d-41ce-83d3-920d4eda271a' with object id 'dca119ef-092d-41ce-83d3-920d4eda271a' does not have authorization to perform action 'Microsoft.Network/virtualNetworks/read' over scope '/subscriptions/b53caa89-ba38-4f04-a0b2-f989c98d4add/resourceGroups/connectivity/providers/Microsoft.Network/virtualNetworks/vnet-demo-app-vnet' or the scope is invalid. If access was recently granted, please refresh your credentials."
+resource "time_sleep" "wait_for_spoke_rg_role" {
+  depends_on      = [azurerm_role_assignment.spoke_rg]
+  create_duration = local.azure_delay
+}
+
 #
 # 3. deploy the actual network
 #
 resource "azurerm_virtual_network" "spoke_vnet" {
   provider   = azurerm.spoke
-  depends_on = [azurerm_role_assignment.spoke_rg]
+  depends_on = [time_sleep.wait_for_spoke_rg_role]
 
   name                = "${var.name}-vnet"
   location            = azurerm_resource_group.spoke_rg.location
@@ -51,8 +67,15 @@ data "azurerm_virtual_network" "hub_vnet" {
   resource_group_name = data.azurerm_resource_group.hub_rg.name
 }
 
+# azure sometimes does not find the new spokle vnet for creating the peer, hence also giving this a delay
+resource "time_sleep" "wait_before_peering" {
+  depends_on      = [azurerm_virtual_network.spoke_vnet]
+  create_duration = local.azure_delay
+}
+
 resource "azurerm_virtual_network_peering" "spoke_hub_peer" {
-  provider = azurerm.spoke
+  provider   = azurerm.spoke
+  depends_on = [time_sleep.wait_before_peering]
 
   name                      = var.name
   resource_group_name       = azurerm_resource_group.spoke_rg.name
@@ -61,7 +84,8 @@ resource "azurerm_virtual_network_peering" "spoke_hub_peer" {
 }
 
 resource "azurerm_virtual_network_peering" "hub_spoke_peer" {
-  provider = azurerm.hub
+  provider   = azurerm.hub
+  depends_on = [time_sleep.wait_before_peering]
 
   name                      = var.name
   resource_group_name       = data.azurerm_resource_group.hub_rg.name

--- a/kit/azure/buildingblocks/connectivity/buildingblock/variables.tf
+++ b/kit/azure/buildingblocks/connectivity/buildingblock/variables.tf
@@ -24,3 +24,9 @@ variable "spoke_owner_principal_id" {
   description = "Principal id that will become owner of the spokes. Defaults to the client_id of the spoke azurerm provider."
   default     = null
 }
+
+variable "azure_delay_seconds" {
+  type        = number
+  description = "Number of additional seconds to wait between Azure API operations to mitigate eventual consistency issues in order to increase automation reliabilty."
+  default     = 30
+}

--- a/kit/azure/buildingblocks/connectivity/buildingblock/versions.tf
+++ b/kit/azure/buildingblocks/connectivity/buildingblock/versions.tf
@@ -8,5 +8,10 @@ terraform {
       version               = ">=3.71.0"
       configuration_aliases = [azurerm.spoke, azurerm.hub]
     }
+
+    time = {
+      source  = "hashicorp/time"
+      version = "0.11.1"
+    }
   }
 }


### PR DESCRIPTION
This is certainly not an elegant nor always successful workaround.
However it should significantly increase the "first time deploy"
reliability of this buildingblock.

closes #72
