### PR TITLE
fix: use github-hosted png for the likvid bank logo

### DIFF
--- a/kit/foundation/meshstack/guides/guide_internal_branding.md
+++ b/kit/foundation/meshstack/guides/guide_internal_branding.md
@@ -20,7 +20,7 @@ To drive adoption and ensure professional communication, the platform team wants
 - Tick **prefix internal name to all email subjects**. This ensures all emails start with “Likvid Developer Platform” for consistency.
 - Set the **sender email address** to `likvid-developer-platform@likvidbank.com`.
 - Set the **reply-to email address** to `likvid-developer-platform@likvidbank.com`.
-- Set the **email header logo** to the following file: ![image](./likvid_logo.png).
+- Set the **email header logo** to the following file: ![image](https://raw.githubusercontent.com/likvid-bank/likvid-cloudfoundation/1e5d5e9b99c105060d10bc604c0cf8f1aafef414/kit/foundation/meshstack/guides/likvid_logo.png).
 - Set the **button color** to **Likvid Bank Blue** (`#0072C6`) for consistency with the brand.
 - Set the **button text** to `Open Likvid Developer Platform` to provide a clear call to action.
 - Set the e-mail signature to


### PR DESCRIPTION
it's currently very difficult to include assets with our guides as that
would need to go through terraform state, which is very complex.

This is a bit of a hack of course but we can figure out a better solution
if we absolutely need that more often
