### PR TITLE
feat: wire STACKIT SKE hub modules into LCF

### DIFF
--- a/foundations/likvid-prod/platforms/stackit/buildingblocks/ske-starterkit/terragrunt.hcl
+++ b/foundations/likvid-prod/platforms/stackit/buildingblocks/ske-starterkit/terragrunt.hcl
@@ -1,0 +1,61 @@
+include "common" {
+  path = find_in_parent_folders("common.hcl")
+}
+
+include "platform" {
+  path   = find_in_parent_folders("platform.hcl")
+  expose = true
+}
+
+locals {
+  hub_git_ref = "main"
+}
+
+dependency "meshplatform" {
+  config_path = "../../meshplatform"
+}
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite"
+  contents  = <<EOF
+provider "meshstack" {
+  endpoint  = "https://federation.demo.meshcloud.io"
+  apikey    = "6169f530-0eaa-4f7f-91b7-c4fd4aaf2a74"
+  apisecret = "${get_env("MESHSTACK_API_KEY_CLOUDFOUNDATION")}"
+}
+EOF
+}
+
+terraform {
+  source = "https://github.com/meshcloud/meshstack-hub.git//modules/stackit/ske/starterkit?ref=${local.hub_git_ref}"
+}
+
+inputs = {
+  hub = {
+    git_ref = local.hub_git_ref
+  }
+
+  meshstack = {
+    owning_workspace_identifier = "admin"
+  }
+
+  starterkit = {
+    full_platform_identifier = "ske1"
+
+    landing_zone_dev_identifier  = "ske1-default"
+    landing_zone_prod_identifier = "ske1-default"
+
+    git_repo_definition_uuid         = "" # TODO: fill after git-repo BBD is deployed
+    git_repo_definition_version_uuid = "" # TODO: fill after git-repo BBD is deployed
+  }
+
+  project_tags_yaml = yamlencode({
+    dev = {
+      environment = ["dev"]
+    }
+    prod = {
+      environment = ["prod"]
+    }
+  })
+}

--- a/foundations/likvid-prod/platforms/stackit/meshplatform/terragrunt.hcl
+++ b/foundations/likvid-prod/platforms/stackit/meshplatform/terragrunt.hcl
@@ -1,0 +1,58 @@
+include "common" {
+  path = find_in_parent_folders("common.hcl")
+}
+
+include "platform" {
+  path   = find_in_parent_folders("platform.hcl")
+  expose = true
+}
+
+locals {
+  # Pin hub ref for both module source and BBD implementation ref_name
+  hub_git_ref = "main"
+  token       = get_env("STACKIT_SERVICE_ACCOUNT_TOKEN")
+}
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite"
+  contents  = <<EOF
+provider "stackit" {
+  region                = "eu01"
+  service_account_token = "${local.token}"
+}
+
+provider "meshstack" {
+  endpoint  = "https://federation.demo.meshcloud.io"
+  apikey    = "6169f530-0eaa-4f7f-91b7-c4fd4aaf2a74"
+  apisecret = "${get_env("MESHSTACK_API_KEY_CLOUDFOUNDATION")}"
+}
+EOF
+}
+
+terraform {
+  source = "https://github.com/meshcloud/meshstack-hub.git//modules/stackit/ske?ref=${local.hub_git_ref}"
+}
+
+inputs = {
+  hub = {
+    git_ref = local.hub_git_ref
+  }
+
+  meshstack = {
+    owning_workspace_identifier = "admin"
+  }
+
+  ske = {
+    platform_identifier = "ske1"
+    location_identifier = "sovereign"
+
+    base_url               = "https://api.ske-demo.d2695c1f95.s.ske.eu01.onstackit.cloud"
+    disable_ssl_validation = true
+    namespace_name_pattern = "#{workspaceIdentifier}-#{projectIdentifier}"
+  }
+
+  stackit_project_id = "272f2ba5-fa0a-4b8b-8ceb-e68165a87914"
+  cluster_name       = "ske-demo"
+  region             = "eu01"
+}


### PR DESCRIPTION
## Summary

Adds terragrunt configs to wire the new STACKIT SKE hub modules into the LCF, following the same pattern as the AKS starterkit refactoring.

### Changes
- `meshplatform/terragrunt.hcl` — sources hub `modules/stackit/ske` (backplane + platform + landing zone registration)
- `buildingblocks/ske-starterkit/terragrunt.hcl` — sources hub `modules/stackit/ske/starterkit` (starterkit BBD composition)

### Dependencies
- Requires hub modules PR: https://github.com/meshcloud/meshstack-hub/pull/116