### PR TITLE
refactor(stackit/storage-buckets): single source of truth for hub coordinates

### DIFF
--- a/.agents/skills/foundation-modules/SKILL.md
+++ b/.agents/skills/foundation-modules/SKILL.md
@@ -86,14 +86,14 @@ echo $NEW_REF
 
 ### Step 2 — Update the LCF git_ref and apply
 
-In the LCF module's `main.tf`, update `local.hub.git_ref`:
+Hub coordinates are the single source of truth in the module's `hub.hcl`. Update `git_ref` there — the deployment (`main.tf` via `var.hub`) and the sibling `e2e/` both read this one file, so there is nothing to keep in sync:
 
 ```hcl
+# hub.hcl
 locals {
-  hub = {
-    git_ref   = "<new-full-sha>"   # paste $NEW_REF here
-    bbd_draft = true
-  }
+  module    = "stackit/storage-bucket"
+  git_ref   = "<new-full-sha>"   # paste $NEW_REF here
+  bbd_draft = true
 }
 ```
 
@@ -108,7 +108,7 @@ The apply updates the Building Block Definition in meshStack with the new conten
 
 ### Step 3 — Run the e2e smoke test
 
-The `e2e/` sibling directory sources the hub's own `e2e/` module at the same git ref the deployment uses. It reads all configuration from the parent deployment's Terraform outputs — no duplication.
+The `e2e/` sibling directory sources the hub's own `e2e/` module at the same git ref the deployment uses. The module path + git ref come from the shared `hub.hcl` (via `include "hub" { expose = true }`); the remaining smoke-test inputs (workspace, BBD version_ref) are read from the parent deployment's Terraform outputs.
 
 ```bash
 cd foundations/likvid-prod/platforms/<provider>/buildingblocks/<service>/e2e
@@ -127,7 +127,31 @@ Success! 1 passed, 0 failed.
 
 ## Setting Up a New e2e Smoke Test
 
-For a building block that doesn't yet have `e2e/terragrunt.hcl`, create it using this exact pattern (verified 2026-06-10):
+For a building block that doesn't yet have `e2e/terragrunt.hcl`, create it using this pattern.
+
+**Hub coordinates: single source of truth in `hub.hcl`.** `terraform.source` *must* be a statically-known expression — Terragrunt evaluates it during `--all` module discovery, **before** dependency outputs exist, so reading `dependency.deployment.outputs.*` into `source` fails with `Unsuitable value: value must be known`. Put the module path + git ref in a sibling `hub.hcl` (a plain locals file, statically readable) and `include` it in both the deployment and the e2e config:
+
+**`hub.hcl`** (in the deployment dir, next to `main.tf`):
+
+```hcl
+locals {
+  module    = "stackit/storage-bucket"
+  git_ref   = "<full-sha>"
+  bbd_draft = true
+}
+```
+
+The deployment's `terragrunt.hcl` exposes it and passes it to `main.tf` as `var.hub`:
+
+```hcl
+include "hub" {
+  path   = "./hub.hcl"   # find_in_parent_folders can't see the current dir; use a relative path
+  expose = true
+}
+inputs = { hub = include.hub.locals }
+```
+
+and `main.tf` declares `variable "hub" { type = object({ module = string, git_ref = string, bbd_draft = bool }) }`.
 
 **`e2e/terragrunt.hcl`:**
 
@@ -136,8 +160,13 @@ dependency "deployment" {
   config_path = "../"
 }
 
+include "hub" {
+  path   = "../hub.hcl"
+  expose = true
+}
+
 terraform {
-  source = "git::https://github.com/meshcloud/meshstack-hub.git//modules/${dependency.deployment.outputs.hub.module}/e2e?ref=${dependency.deployment.outputs.hub.git_ref}"
+  source = "git::https://github.com/meshcloud/meshstack-hub.git//modules/${include.hub.locals.module}/e2e?ref=${include.hub.locals.git_ref}"
 }
 
 generate "provider" {
@@ -221,10 +250,11 @@ output "hub" {
 
 Hub modules are sourced from `github.com/meshcloud/meshstack-hub.git` at a pinned git ref. To upgrade:
 
-**1. Update the git ref** in `main.tf` (or wherever `local.hub` is defined):
+**1. Update the git ref** in `hub.hcl` (the single source of truth, read by both the deployment and the sibling `e2e/`):
 
 ```hcl
-hub = {
+# hub.hcl
+locals {
   git_ref = "<new-full-sha>"
 }
 ```

--- a/foundations/likvid-prod/platforms/stackit/buildingblocks/projects/test/terragrunt.hcl
+++ b/foundations/likvid-prod/platforms/stackit/buildingblocks/projects/test/terragrunt.hcl
@@ -1,4 +1,4 @@
-# TODO: this entire module should be re-built on top of 
+# TODO: this entire module should be re-built on top of
 # https://github.com/meshcloud/meshstack-hub/blob/main/modules/stackit/meshstack_integration.tf
 # instead
 

--- a/foundations/likvid-prod/platforms/stackit/buildingblocks/storage-buckets/e2e/terragrunt.hcl
+++ b/foundations/likvid-prod/platforms/stackit/buildingblocks/storage-buckets/e2e/terragrunt.hcl
@@ -2,18 +2,14 @@ dependency "deployment" {
   config_path = "../"
 }
 
-locals {
-  # Hub coordinates are read from deployment outputs at generate-time (not in terraform.source).
-  # terraform.source must be a static expression because Terragrunt evaluates it during
-  # `--all` module discovery before dependency outputs are available, causing an
-  # "Unsuitable value: value must be known" error.
-  # Keep this ref in sync with local.hub.git_ref in the sibling main.tf.
-  hub_module  = "stackit/storage-bucket"
-  hub_git_ref = "3504c9c50862927ee1ae23711a6937d613b81e1a"
+# Hub coordinates: single source of truth in the sibling deployment's hub.hcl.
+include "hub" {
+  path   = "../hub.hcl"
+  expose = true
 }
 
 terraform {
-  source = "git::https://github.com/meshcloud/meshstack-hub.git//modules/${local.hub_module}/e2e?ref=${local.hub_git_ref}"
+  source = "git::https://github.com/meshcloud/meshstack-hub.git//modules/${include.hub.locals.module}/e2e?ref=${include.hub.locals.git_ref}"
 }
 
 generate "provider" {

--- a/foundations/likvid-prod/platforms/stackit/buildingblocks/storage-buckets/hub.hcl
+++ b/foundations/likvid-prod/platforms/stackit/buildingblocks/storage-buckets/hub.hcl
@@ -1,0 +1,7 @@
+# Hub building-block coordinates — single source of truth for both the
+# deployment (main.tf, via terragrunt input) and the e2e smoke test.
+locals {
+  module    = "stackit/storage-bucket"
+  git_ref   = "6447579b2e04cfb405de6b4f9105322794db48aa"
+  bbd_draft = true
+}

--- a/foundations/likvid-prod/platforms/stackit/buildingblocks/storage-buckets/main.tf
+++ b/foundations/likvid-prod/platforms/stackit/buildingblocks/storage-buckets/main.tf
@@ -3,12 +3,16 @@ variable "ci_service_account_email" {
   type        = string
 }
 
+variable "hub" {
+  description = "Hub building-block coordinates (single source of truth in hub.hcl, passed in by terragrunt)"
+  type = object({
+    module    = string
+    git_ref   = string
+    bbd_draft = bool
+  })
+}
+
 locals {
-  hub = {
-    module    = "stackit/storage-bucket"
-    git_ref   = "3504c9c50862927ee1ae23711a6937d613b81e1a"
-    bbd_draft = true
-  }
   meshstack = {
     owning_workspace_identifier = "devops-platform"
   }
@@ -53,9 +57,9 @@ resource "stackit_authorization_project_role_assignment" "ci_sa" {
 }
 
 module "stackit_storage_bucket_bb" {
-  source = "git::https://github.com/meshcloud/meshstack-hub.git//modules/${local.hub.module}?ref=${local.hub.git_ref}"
+  source = "git::https://github.com/meshcloud/meshstack-hub.git//modules/${var.hub.module}?ref=${var.hub.git_ref}"
 
-  hub                = local.hub
+  hub                = var.hub
   stackit_project_id = meshstack_tenant_v4.stackit_storage_buckets.spec.platform_tenant_id
   meshstack          = local.meshstack
 }

--- a/foundations/likvid-prod/platforms/stackit/buildingblocks/storage-buckets/outputs.tf
+++ b/foundations/likvid-prod/platforms/stackit/buildingblocks/storage-buckets/outputs.tf
@@ -1,6 +1,6 @@
 output "e2e" {
   value = {
-    hub                       = local.hub
+    hub                       = var.hub
     building_block_definition = module.stackit_storage_bucket_bb.building_block_definition
     owning_workspace          = local.meshstack.owning_workspace_identifier
   }

--- a/foundations/likvid-prod/platforms/stackit/buildingblocks/storage-buckets/terragrunt.hcl
+++ b/foundations/likvid-prod/platforms/stackit/buildingblocks/storage-buckets/terragrunt.hcl
@@ -6,12 +6,19 @@ include "platform" {
   path = find_in_parent_folders("platform.hcl")
 }
 
+# Hub coordinates live in hub.hcl (single source of truth, shared with e2e/).
+include "hub" {
+  path   = "./hub.hcl"
+  expose = true
+}
+
 dependency "bootstrap" {
   config_path = "../../bootstrap"
 }
 
 inputs = {
   ci_service_account_email = dependency.bootstrap.outputs.ci_service_account_email
+  hub                      = include.hub.locals
 }
 
 


### PR DESCRIPTION
Supersedes #209 (same refactor commit, plus a pre-commit lint fix to get `check` green).

## Commits

1. **`refactor(stackit/storage-buckets)`** — single source of truth for hub coordinates.
2. **`style`** — strip trailing whitespace in `projects/test/terragrunt.hcl` (unrelated pre-existing lint failure; pre-commit runs `--all-files`).

## What (commit 1)

Hub module coordinates (`module` + `git_ref`) were duplicated in `main.tf` (`local.hub`) and `e2e/terragrunt.hcl`, kept in sync by hand via a "keep this ref in sync" comment.

This extracts them to a shared **`hub.hcl`** (single source of truth), read by both terragrunt configs via `include "hub" { expose = true }`. `main.tf` now consumes `hub` as an input variable.

### Why the comment existed (and why `hub.hcl` solves it)

`terraform.source` must be statically known — Terragrunt evaluates it during `--all` discovery, *before* dependency outputs exist, so the e2e couldn't read the deployment's outputs for its `source`. A plain locals-only `hub.hcl` is statically readable at discovery time, so both configs share it without duplication.

### Also

- Bumps the hub ref to `6447579b2e04cfb405de6b4f9105322794db48aa`.
- Updates the `foundation-modules` skill to document the `hub.hcl` pattern.

## Verified locally

- `terragrunt hcl fmt --check` passes on all touched HCL.
- Deployment `plan`: clean `0 add, 1 change, 0 destroy` (only the BBD `content_hash` bump).
- Deployment applied; **e2e smoke test passes** locally and in CI on PR #209 (`platforms test (stackit) ✓`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)