### PR TITLE
chore(gcp): add agrub to the foundation engineers group

### DIFF
--- a/foundations/likvid-prod/platforms/gcp/platform.hcl
+++ b/foundations/likvid-prod/platforms/gcp/platform.hcl
@@ -19,7 +19,7 @@ locals {
       "fnowarre@meshcloud.io",
       "hdettmer@meshcloud.io",
     ]
-    foundation_engineers = ["ckraus@meshcloud.io", "jschwandke@meshcloud.io"]
+    foundation_engineers = ["ckraus@meshcloud.io", "jschwandke@meshcloud.io", "agrub@meshcloud.io"]
   }
 }
 


### PR DESCRIPTION
@henryde — could you **review, apply and merge** this? It unblocks my work on the STACKIT landing zone reference architecture, and I cannot apply it myself (see below).

## What it does

Adds `agrub@meshcloud.io` to `pam.foundation_engineers` in `foundations/likvid-prod/platforms/gcp/platform.hcl`. That list is concatenated into the `likvid-foundation-platform-engineers@meshcloud.io` group in `platforms/gcp/bootstrap/terragrunt.hcl`, and that group holds `roles/editor` on `likvid-prod-management` plus `roles/storage.admin` on the `foundation-likvid-prod-tf-states` bucket.

## Why

Every terragrunt unit under `foundations/likvid-prod/platforms/stackit/` fails at backend init:

```
tofu: Initializing the backend...
Error: Failed to get existing workspaces: querying Cloud Storage failed: googleapi: Error 403:
agrub@meshcloud.io does not have storage.objects.list access to the Google Cloud Storage bucket.
Permission 'storage.objects.list' denied on resource
'//storage.googleapis.com/projects/_/buckets/foundation-likvid-prod-tf-states', forbidden
```

`platforms/stackit/platform.hcl` stores that whole subtree's state in the same bucket as the GCP platform, so this blocks `bootstrap`, `buildingblocks/storage-buckets` and the new landing-zone unit I am adding. A control run against `meshcloud-tf-states` with the same credentials initialises fine, so it is this bucket specifically.

## Why I cannot apply it myself

It is circular. `platforms/gcp/platform.hcl` puts the gcp bootstrap unit's own state in `foundation-likvid-prod-tf-states`, so `terragrunt plan` in `platforms/gcp/bootstrap` fails with the same 403. Applying the grant requires access the grant would provide.

## Expected plan

I could not run it, so this is read off `kit/gcp/bootstrap`:

- **1 to add** — `google_cloud_identity_group_membership.platform_engineers["agrub@meshcloud.io"]` (`main.tf:56`). `for_each` runs over a `set(string)`, so a new element adds one keyed instance and touches none of the existing five.
- **No bucket IAM change** — `google_storage_bucket_iam_policy.terraform_state` binds `roles/storage.admin` to the group, not to individuals (`resources.tf-state.tf:61-62`).
- Generated documentation changes, since `documentation.tf:19` renders the member list.

## Applying

`platforms/gcp/bootstrap` carries `exclude { if = true, actions = ["all"] }`, so CI will not pick this up — it needs `terragrunt apply` by hand in that directory. The group lives in the `meshcloud.io` directory, not `dev.meshcloud.io`.

CI on this PR can be ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)